### PR TITLE
Support nesting

### DIFF
--- a/livejson.py
+++ b/livejson.py
@@ -8,7 +8,8 @@ import os
 import json
 
 
-# HELPFUL HELPERS
+# MISC HELPERS
+
 
 class _ObjectBase(object):
     """ Class inherited by most stuff. Implements the lowest common denominator
@@ -41,7 +42,8 @@ class _ObjectBase(object):
         return repr(self.data)
 
 
-# NESTING
+# NESTING CLASSES
+
 
 class _NestedBase(_ObjectBase):
     """ Inherited by _NestedDict and _NestedList, implements methods common
@@ -73,7 +75,7 @@ class _NestedBase(_ObjectBase):
         # the whole thing
         d[key] = value
         # Update the whole database with the modification
-        self.basedb._update(data)
+        self.basedb.setdata(data)
 
     def __delitem__(self, key):
         # See __setitem__ for details on how this works
@@ -82,7 +84,7 @@ class _NestedBase(_ObjectBase):
         for i in self.pathInData:
             d = d[i]
         del d[key]
-        self.basedb._update(data)
+        self.basedb.setdata(data)
 
 
 class _NestedDict(_NestedBase, collections.MutableMapping):
@@ -98,10 +100,11 @@ class _NestedList(_NestedBase, collections.MutableSequence):
         for i in self.pathInData:
             d = d[i]
         d.insert(index, value)
-        self.basedb._update(data)
+        self.basedb.setdata(data)
 
 
-# THE MAIN STUFF
+# THE MAIN CLASSES
+
 
 class _BaseDatabase(_ObjectBase):
     """ Class inherited by DictDatabase that implements all the required
@@ -125,9 +128,11 @@ class _BaseDatabase(_ObjectBase):
         with open(self.path, "w") as f:
             json.dump(data, f)
 
-    def _update(self, data):
+    # Bonus features!
+
+    def setdata(self, data):
         """ Overwrite the database with new data. You probably shouldn't do
-        this yourself, it's easy to screw up. """
+        this yourself, it's easy to screw up your whole database with this """
         with open(self.path, "w") as f:
             json.dump(data, f)
 
@@ -154,6 +159,10 @@ class DictDatabase(_BaseDatabase, collections.MutableMapping):
 
     def __iter__(self):
         return iter(self.data)
+
+    def cleardata(self):
+        """ Delete everything. Dangerous. """
+        self.setdata({})
 
 
 class ListDatabase(_BaseDatabase, collections.MutableSequence):
@@ -182,6 +191,10 @@ class ListDatabase(_BaseDatabase, collections.MutableSequence):
         data.insert(index, value)
         with open(self.path, "w") as f:
             json.dump(data, f)
+
+    def cleardata(self):
+        """ Delete everything. Dangerous. """
+        self.setdata([])
 
 
 def Database(path):

--- a/test.py
+++ b/test.py
@@ -54,6 +54,27 @@ class testDatabase(unittest.TestCase):
         self.assertIsInstance(db.data, list)
         self.assertEqual(db.data, ["turtles", "dogs", "cats", "penguins"])
 
+    def test_nesting(self):
+        """ Test that you can also work with dicts and lists that appear inside
+        the database, rather than as the top-level object """
+        my_db = livejson.Database(self.dbpath)
+        my_db.cleardata()
+        # Test nested dicts
+        my_db["stored_data"] = {}
+        my_db["stored_data"]["test"] = "value"
+        self.assertEqual(my_db.data, {"stored_data": {"test": "value"}})
+        # Test nested lists
+        my_db["stored_data"] = []
+        my_db["stored_data"].append("test")
+        self.assertEqual(my_db.data, {"stored_data": ["test"]})
+        # Test more complex multilevel nesting
+        my_db["stored_data"] = []
+        my_db["stored_data"].append({})
+        my_db["stored_data"][0]["colors"] = ["green", "purple"]
+        self.assertEqual(my_db.data,
+                         {"stored_data": [{"colors": ["green", "purple"]}]}
+                         )
+
     def tearDown(self):
         os.remove(self.dbpath)
 


### PR DESCRIPTION
Allow for the nesting of objects, like having a `dict` or a `list` inside your `Database`

For example:

```
import livejson
my_db = livejson.Database("test.json")
my_db['data'] = {}
my_db['data']['dogs'] = 'cats'
```

will now work properly.

This also includes all the tests and stuff.
