### PR TITLE
Grouped writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Python library implementing a `dict`-like object that writes to a file as it i
 - **Flexible**: `livejson` fully supports complex nestings of `list`s and `dict`s, meaning it can represent any valid JSON file.
 - **Compatible**: `livejson` works perfectly on both Python 2 and Python 3.
 - **Lightweight**: `livejson` is a single file with no external dependencies. Just install and go!
-- **Reliable**: no caching is used. Every single time you access a `livejson.Database`, it's read straight from the file. And every time you write to it, the change is instant. No delays, no conflicts.
+- **Reliable**: by default, no caching is used. Every single time you access a `livejson.Database`, it's read straight from the file. And every time you write to it, the change is instant. No delays, no conflicts. However, if efficiency is important, you can use the context manager, which allows interaction with `livejson` through [transactions](https://en.wikipedia.org/wiki/Database_transaction).
 - **100% test covered** Yay 🎉
 
 `livejson` can be used for:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Python library implementing a `dict`-like object that writes to a file as it i
 - **Flexible**: `livejson` fully supports complex nestings of `list`s and `dict`s, meaning it can represent any valid JSON file.
 - **Compatible**: `livejson` works perfectly on both Python 2 and Python 3.
 - **Lightweight**: `livejson` is a single file with no external dependencies. Just install and go!
-- **Reliable**: by default, no caching is used. Every single time you access a `livejson.Database`, it's read straight from the file. And every time you write to it, the change is instant. No delays, no conflicts. However, if efficiency is important, you can use the context manager, which allows interaction with `livejson` through [transactions](https://en.wikipedia.org/wiki/Database_transaction).
+- **Reliable**: by default, no caching is used. Every single time you access a `livejson.Database`, it's read straight from the file. And every time you write to it, the change is instant. No delays, no conflicts. However, if efficiency is important, you can use the context manager to perfomrm "grouped writes", which allow for performing a large number of operations with only one write at the end.
 - **100% test covered** Yay 🎉
 
 `livejson` can be used for:

--- a/livejson.py
+++ b/livejson.py
@@ -216,6 +216,7 @@ class _BaseDatabase(_ObjectBase):
 
     def __enter__(self):
         self.cache = {}
+        return self
 
     def __exit__(self, *args):
         # We have to write manually here because __setitem__ is set up to write

--- a/livejson.py
+++ b/livejson.py
@@ -194,6 +194,12 @@ class _BaseDatabase(_ObjectBase):
         """ Delete the database from the disk completely """
         os.remove(self.path)
 
+    @property
+    def file_contents(self):
+        """ Get the raw file contents of the database """
+        with open(self.path, "r") as f:
+            return f.read()
+
 
 class DictDatabase(_BaseDatabase, collections.MutableMapping):
     """ A class emulating Python's dict that will update a JSON file as it is

--- a/livejson.py
+++ b/livejson.py
@@ -149,6 +149,8 @@ class _BaseDatabase(_ObjectBase):
                 "list" if isinstance(self, ListDatabase) else "dict")
 
     def _data(self):
+        """ A simplified version of 'data' to avoid infinite recursion in some
+        cases. Don't use this. """
         if self.is_caching:
             return self.cache
         with open(self.path, "r") as f:
@@ -156,7 +158,7 @@ class _BaseDatabase(_ObjectBase):
 
     @property
     def data(self):
-        """ Get a vanilla dict object (fresh from the JSON file) """
+        """ Get a vanilla dict object to represent the database """
         # Update type in case it's changed
         self._updateType()
         # And return

--- a/livejson.py
+++ b/livejson.py
@@ -148,13 +148,19 @@ class _BaseDatabase(_ObjectBase):
         _initdb(self.path,
                 "list" if isinstance(self, ListDatabase) else "dict")
 
+    def _data(self):
+        if self.is_caching:
+            return self.cache
+        with open(self.path, "r") as f:
+            return json.load(f)
+
     @property
     def data(self):
         """ Get a vanilla dict object (fresh from the JSON file) """
         # Update type in case it's changed
         self._updateType()
-        with open(self.path, "r") as f:
-            return json.load(f)
+        # And return
+        return self._data()
 
     def __setitem__(self, key, value):
         self._checkType(key)
@@ -170,9 +176,7 @@ class _BaseDatabase(_ObjectBase):
     def _updateType(self):
         """ Make sure that the class behaves like the data structure that it
         is, so that we don't get a ListDatabase trying to represent a dict """
-        # Do this manually to avoid infinite recursion
-        with open(self.path, "r") as f:
-            data = json.load(f)
+        data = self._data()
         # Change type if needed
         if isinstance(data, dict) and isinstance(self, ListDatabase):
             self.__class__ = DictDatabase

--- a/livejson.py
+++ b/livejson.py
@@ -207,11 +207,11 @@ class _BaseDatabase(_ObjectBase):
         with open(self.path, "r") as f:
             return f.read()
 
-    # Transactions
+    # Grouped writes
 
     @property
     def is_caching(self):
-        """ Is a transaction underway? """
+        """ Is a grouped write underway? """
         return hasattr(self, "cache")
 
     def __enter__(self):

--- a/livejson.py
+++ b/livejson.py
@@ -216,7 +216,7 @@ class _BaseDatabase(_ObjectBase):
 
     def __enter__(self):
         self.cache = {}
-        return self
+        return self  # This enables using "as"
 
     def __exit__(self, *args):
         # We have to write manually here because __setitem__ is set up to write
@@ -296,3 +296,7 @@ class Database(object):
             db = Database(path)
             db.set_data(data)
             return db
+
+
+# Alias
+File = Database

--- a/livejson.py
+++ b/livejson.py
@@ -160,14 +160,12 @@ class _BaseDatabase(_ObjectBase):
         self._checkType(key)
         data = self.data
         data[key] = value
-        with open(self.path, "w") as f:
-            json.dump(data, f)
+        self.set_data(data)
 
     def __delitem__(self, key):
         data = self.data
         del data[key]
-        with open(self.path, "w") as f:
-            json.dump(data, f)
+        self.set_data(data)
 
     def _updateType(self):
         """ Make sure that the class behaves like the data structure that it
@@ -226,8 +224,7 @@ class ListDatabase(_BaseDatabase, collections.MutableSequence):
     def insert(self, index, value):
         data = self.data
         data.insert(index, value)
-        with open(self.path, "w") as f:
-            json.dump(data, f)
+        self.set_data(data)
 
     def clear_data(self):
         """ Delete everything. Dangerous. """

--- a/test.py
+++ b/test.py
@@ -165,8 +165,8 @@ class TestNesting(_DatabaseTest, unittest.TestCase):
             db["data"][0] = "abc"
 
 
-class TestTransactions(_DatabaseTest, unittest.TestCase):
-    """ Test using transactions with the context manager. These improve
+class TestGroupedWrites(_DatabaseTest, unittest.TestCase):
+    """ Test using "grouped writes" with the context manager. These improve
     efficiency by only writing to the file once, at the end, instead of
     writing every change as it is made. """
     def test_basics(self):
@@ -178,7 +178,7 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
         self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
 
     def test_switchclass(self):
-        """ Test the switching of classes during a transaction """
+        """ Test the switching of classes in the middle of a grouped write """
         db = livejson.Database(self.dbpath)
         with db:
             self.assertIsInstance(db, livejson.DictDatabase)
@@ -189,7 +189,7 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
 
     def test_misc(self):
         """ Test miscellaneous other things that seem like they might break
-        with a transaction """
+        with a grouped write """
         db = livejson.Database(self.dbpath)
         # Test is_caching, and test that data works with the cache
         self.assertEqual(db.is_caching, False)
@@ -202,7 +202,7 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
 
     def test_fun_syntax(self):
         """ This is a fun bit of "syntactic sugar" enabled as a side effect of
-        transactions """
+        grouped writes """
         with livejson.Database(self.dbpath) as a:
             a["cats"] = "dogs"
         with open(self.dbpath, "r") as f:

--- a/test.py
+++ b/test.py
@@ -177,8 +177,19 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
             self.assertEqual(db.file_contents, "{}")
         self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
 
+    def test_switchclass(self):
+        """ Test the switching of classes during a transaction """
+        db = livejson.Database(self.dbpath)
+        with db:
+            self.assertIsInstance(db, livejson.DictDatabase)
+            db.set_data([])
+            self.assertIsInstance(db, livejson.ListDatabase)
+            self.assertEqual(db.file_contents, "{}")
+        self.assertEqual(db.file_contents, "[]")
+
     def test_misc(self):
         db = livejson.Database(self.dbpath)
+        # Test is_caching, and test that data works with the cache
         self.assertEqual(db.is_caching, False)
         with db:
             self.assertEqual(db.is_caching, True)

--- a/test.py
+++ b/test.py
@@ -166,7 +166,10 @@ class TestNesting(_DatabaseTest, unittest.TestCase):
 
 
 class TestTransactions(_DatabaseTest, unittest.TestCase):
-    def test_context_manager(self):
+    """ Test using transactions with the context manager. These improve
+    efficiency by only writing to the file once, at the end, instead of
+    writing every change as it is made. """
+    def test_basics(self):
         db = livejson.Database(self.dbpath)
         with db:
             db["a"] = "b"
@@ -174,6 +177,15 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
             self.assertEqual(db.file_contents, "{}")
         self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
 
+    def test_misc(self):
+        db = livejson.Database(self.dbpath)
+        self.assertEqual(db.is_caching, False)
+        with db:
+            self.assertEqual(db.is_caching, True)
+            db["a"] = "b"
+            # Test that data reflects the cache
+            self.assertEqual(db.data, {"a": "b"})
+        self.assertEqual(db.is_caching, False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -59,6 +59,8 @@ class TestDatabase(_DatabaseTest, unittest.TestCase):
         db["a"] = "b"
         # Test 'data' (get a vanilla dict object)
         self.assertEqual(db.data, {"a": "b"})
+        # Test file_contents
+        self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
         # Test __str__ and __repr__
         self.assertEqual(str(db), str(db.data))
         self.assertEqual(repr(db), repr(db.data))

--- a/test.py
+++ b/test.py
@@ -208,11 +208,13 @@ class TestGroupedWrites(_DatabaseTest, unittest.TestCase):
 
     def test_fun_syntax(self):
         """ This is a fun bit of "syntactic sugar" enabled as a side effect of
-        grouped writes """
-        with livejson.Database(self.dbpath) as a:
+        grouped writes. I also aliased "File" to "Database" to improve
+        readability in some cases. """
+        with livejson.File(self.dbpath) as a:
             a["cats"] = "dogs"
         with open(self.dbpath, "r") as f:
             self.assertEqual(f.read(), "{\"cats\": \"dogs\"}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -188,6 +188,8 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
         self.assertEqual(db.file_contents, "[]")
 
     def test_misc(self):
+        """ Test miscellaneous other things that seem like they might break
+        with a transaction """
         db = livejson.Database(self.dbpath)
         # Test is_caching, and test that data works with the cache
         self.assertEqual(db.is_caching, False)

--- a/test.py
+++ b/test.py
@@ -200,5 +200,13 @@ class TestTransactions(_DatabaseTest, unittest.TestCase):
             self.assertEqual(db.data, {"a": "b"})
         self.assertEqual(db.is_caching, False)
 
+    def test_fun_syntax(self):
+        """ This is a fun bit of "syntactic sugar" enabled as a side effect of
+        transactions """
+        with livejson.Database(self.dbpath) as a:
+            a["cats"] = "dogs"
+        with open(self.dbpath, "r") as f:
+            self.assertEqual(f.read(), "{\"cats\": \"dogs\"}")
+
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -177,6 +177,12 @@ class TestGroupedWrites(_DatabaseTest, unittest.TestCase):
             self.assertEqual(db.file_contents, "{}")
         self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
 
+    def test_lists(self):
+        db = livejson.ListDatabase(self.dbpath)
+        for i in range(10):
+            db.append(i)
+        self.assertEqual(len(db), 10)
+
     def test_switchclass(self):
         """ Test the switching of classes in the middle of a grouped write """
         db = livejson.Database(self.dbpath)

--- a/test.py
+++ b/test.py
@@ -165,5 +165,15 @@ class TestNesting(_DatabaseTest, unittest.TestCase):
             db["data"][0] = "abc"
 
 
+class TestTransactions(_DatabaseTest, unittest.TestCase):
+    def test_context_manager(self):
+        db = livejson.Database(self.dbpath)
+        with db:
+            db["a"] = "b"
+            # Make sure that the write doesn't happen until we exit
+            self.assertEqual(db.file_contents, "{}")
+        self.assertEqual(db.file_contents, "{\"a\": \"b\"}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements a context manager for performing many operations on a JSON file with only one write, which can considerably improve efficiency.

This can, in the simplest case, be used as "syntactic sugar:"

``` python
import livejson
with livejson.File("my_db.json") as db:
    db["cats"] = "dogs"
```

which is fun

In more serious cases, it is used to improve performance by minimizing the number of times files need to be opened and closed when you're doing a lot of writing (e.g. adding many items to a list from within a loop)
