### PR TITLE
Fix collections DeprecationError.

### DIFF
--- a/livejson.py
+++ b/livejson.py
@@ -8,7 +8,8 @@ import os
 import json
 import warnings
 
-# Import from collections.abc for Python 3.x but incase of ImportError, fall back on importing from collections.
+# Import from collections.abc for Python 3.x but incase of ImportError
+# from Python 2.x, fall back on importing from collections.
 try:
     from collections.abc import (
         MutableMapping,
@@ -392,3 +393,4 @@ class File(object):
 Database = File
 ListDatabase = ListFile
 DictDatabase = DictFile
+

--- a/livejson.py
+++ b/livejson.py
@@ -8,10 +8,17 @@ import os
 import json
 import warnings
 
-from collections import (
-    MutableMapping,
-    MutableSequence,
-)
+# Import from collections.abc for Python 3.x but incase of ImportError, fall back on importing from collections.
+try:
+    from collections.abc import (
+        MutableMapping,
+        MutableSequence,
+    )
+except ImportError: 
+    from collections import (
+        MutableMapping,
+        MutableSequence,
+    )
 
 warnings.filterwarnings("once", category=DeprecationWarning)
 


### PR DESCRIPTION
Fix for the Python 3.3+ deprecation error while still creating compatibility for Python 2.x.\
https://github.com/controversial/livejson/issues/17